### PR TITLE
Upgrade pip so that it uses the newest wheels

### DIFF
--- a/image/python.sh
+++ b/image/python.sh
@@ -7,5 +7,6 @@ header "Installing Python..."
 ## Install Python.
 minimal_apt_get_install python python2.7 python3.8 python3.8-dev python3-pip python3-setuptools
 #precache uvloop
+python3.8 -m pip install --upgrade pip
 python3.8 -m pip install wheel
 python3.8 -m pip install uvicorn==0.11.3 gunicorn==20.0.4


### PR DESCRIPTION
This fixes a problem with cryptography (and probably other libraries) that use a different setuptools.